### PR TITLE
Feat/nova bug triage

### DIFF
--- a/ironic_bug_dashboard/__init__.py
+++ b/ironic_bug_dashboard/__init__.py
@@ -82,16 +82,16 @@ async def index(request):
                           if x['importance'] != 'Wishlist']
 
     nova_triaged_bugs = []
-    nova_unconfirmed_undecided = []
+    nova_triage_needed_bugs = []
     for bug in nova_bugs['all']:
-        if (bug['status'] == 'Confirmed' and bug['importance'] != 'Undecided'):
-            nova_triaged_bugs.append(bug)
+        if (bug['status'] == 'New' or bug['importance'] == 'Undecided'):
+            nova_triage_needed_bugs.append(bug)
         else:
-            nova_unconfirmed_undecided.append(bug)
+            nova_triaged_bugs.append(bug)
     nova_triaged_bugs.sort(key=lambda b: (STATUS_PRIORITIES.get(b['status'], 0),
                                         b['date_created']))
 
-    nova_bugs['all'] = nova_unconfirmed_undecided
+    nova_bugs['all'] = nova_triage_needed_bugs
 
     undecided = simple_lp.search_in_results(
         ironic_bugs,

--- a/ironic_bug_dashboard/__init__.py
+++ b/ironic_bug_dashboard/__init__.py
@@ -120,6 +120,7 @@ async def index(request):
     return dict(
         ironic_bugs=ironic_bugs,
         nova_bugs=nova_bugs,
+        nova_triaged_bugs=nova_triaged_bugs,
         triage_needed=triage_needed,
         users=users,
         unassigned_in_progress=unassigned_in_progress,

--- a/ironic_bug_dashboard/__init__.py
+++ b/ironic_bug_dashboard/__init__.py
@@ -81,6 +81,18 @@ async def index(request):
     ironic_bugs['all'] = [x for x in ironic_bugs['all']
                           if x['importance'] != 'Wishlist']
 
+    nova_triaged_bugs = []
+    nova_unconfirmed_undecided = []
+    for bug in nova_bugs['all']:
+        if (bug['status'] == 'Confirmed' and bug['importance'] != 'Undecided'):
+            nova_triaged_bugs.append(bug)
+        else:
+            nova_unconfirmed_undecided.append(bug)
+    nova_triaged_bugs.sort(key=lambda b: (STATUS_PRIORITIES.get(b['status'], 0),
+                                        b['date_created']))
+
+    nova_bugs['all'] = nova_unconfirmed_undecided
+
     undecided = simple_lp.search_in_results(
         ironic_bugs,
         importance='Undecided',

--- a/ironic_bug_dashboard/template.html
+++ b/ironic_bug_dashboard/template.html
@@ -61,6 +61,14 @@ Nova bugs with Ironic tag</a>: {{ nova_bugs['all'] | length }}.
 {% endfor %}
 </ul>
 
+<h2>Nova Triaged Bugs</h2>
+<p>Nova bugs whose importance is not 'Undecided', and status is 'Confirmed'.</p>
+<ul>
+{% for bug in nova_triaged_bugs %}
+{{ render_bug(bug) }}
+{% endfor %}
+</ul>
+
 <h2>Triage Needed</h2>
 <p>Bugs that have 'Undecided' importance or status 'New' or 'Confirmed'.
 Set importance and mark as 'Triaged'.</p>

--- a/ironic_bug_dashboard/template.html
+++ b/ironic_bug_dashboard/template.html
@@ -62,7 +62,7 @@ Nova bugs with Ironic tag</a>: {{ nova_bugs['all'] | length }}.
 </ul>
 
 <h2>Nova Triaged Bugs</h2>
-<p>Nova bugs whose importance is not 'Undecided', and status is 'Confirmed'.</p>
+<p>Nova bugs whose importance is not 'Undecided', or status is not 'New'.</p>
 <ul>
 {% for bug in nova_triaged_bugs %}
 {{ render_bug(bug) }}


### PR DESCRIPTION
## Description
Fixes inconsistency in bug triage between Ironic and Nova projects.

This PR ensures that bugs filed in Nova, in "Confirmed" status with importance set to non-"Undecided", are considered triaged and filtered out.

## Related Issue
--------------
Closes #2 